### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.d/entrypoint.sh
+++ b/entrypoint.d/entrypoint.sh
@@ -31,7 +31,7 @@ if [ ! -z "$LICENSE_KEY" ]; then
 	else
 		if [[ "$file" =~ \.lic$ ]]; then
 			echo -e "License file found. Importing license file: ${file} ..."
-			mv $file /etc/op5license/op5license.lic
+			cp -f $file /etc/op5license/op5license.lic
 			chown apache:apache /etc/op5license/op5license.lic
 			chmod 664 /etc/op5license/op5license.lic
 		else


### PR DESCRIPTION
can we copy the file instead of moving it !? When the license folder  is mounted the license can be kept inside the licenses folder. like so

.
├── Docker-compose.yml
├── README.md
├── backups
└── licenses
    └── license.lic



     volumes:
       - ./licenses:/usr/libexec/entrypoint.d/licenses/
       - ./backups:/usr/libexec/entrypoint.d/backups/
    
     environment:
       LICENSE_KEY: "license.lic"
       IMPORT_BACKUP: "<backup file>.backup"
